### PR TITLE
Support for default extensions (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ dotnet install tool --global dotnet-serve
 Usage: dotnet serve [options]
 
 Options:
-  --version                   Show version information
-  -?|-h|--help                Show help information
-  -d|--directory <DIRECTORY>  The root directory to serve. [Current directory]
-  -p|--port <PORT>            Port to use [8080]. Use 0 for a dynamic port.
-  -a|--address <ADDRESS>      Address to use [0.0.0.0]
-  -o|--open-browser           Open a web browser when the server starts. [false]
-  --path-base <PATH>          The base URL path of postpended to the site url.
-  --razor                     Enable Razor Pages support (Experimental)
+  --version                          Show version information
+  -?|-h|--help                       Show help information
+  -d|--directory <DIRECTORY>         The root directory to serve. [Current directory]
+  -p|--port <PORT>                   Port to use [8080]. Use 0 for a dynamic port.
+  -a|--address <ADDRESS>             Address to use [0.0.0.0]
+  -o|--open-browser                  Open a web browser when the server starts. [false]
+  --path-base <PATH>                 The base URL path of postpended to the site url.
+  --default-extensions:<EXTENSIONS>  A comma-delimited list of extensions to use when no extension is provided in the URL. [.html,.htm]
+  --razor                            Enable Razor Pages support (Experimental)
 ```

--- a/src/dotnet-serve/CommandLineOptions.cs
+++ b/src/dotnet-serve/CommandLineOptions.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Net;
+using System.Linq;
 using McMaster.Extensions.CommandLineUtils;
 
 namespace McMaster.DotNet.Server
@@ -30,8 +31,28 @@ namespace McMaster.DotNet.Server
 
         [Option("--path-base <PATH>", Description = "The base URL path of postpended to the site url.")]
         public string PathBase { get; private set; }
+        
+        [Option("--default-extensions:<EXTENSIONS>", CommandOptionType.SingleOrNoValue, Description = "A comma-delimited list of extensions to use when no extension is provided in the URL. [.html,.htm]")]
+        public (bool HasValue, string Extensions) DefaultExtensions { get; private set; }
 
         [Option("--razor", Description ="Enable Razor Pages support (Experimental)")]
         public bool EnableRazor { get; set; }
+
+        public string GetPathBase()
+        {
+            if(string.IsNullOrEmpty(PathBase))
+            {
+                return PathBase;
+            }
+            var pathBase = PathBase.Replace('\\', '/').TrimEnd('/');
+            return pathBase[0] != '/' ? "/" + pathBase : pathBase;
+        }
+
+        public string[] GetDefaultExtensions() =>
+            DefaultExtensions.HasValue
+                ? string.IsNullOrEmpty(DefaultExtensions.Extensions)
+                    ? new [] { ".html", ".htm" }
+                    : DefaultExtensions.Extensions.Split(',').Select(x => x.StartsWith('.') ? x : "." + x).ToArray()
+                : null;
     }
 }

--- a/src/dotnet-serve/DefaultExtensions/DefaultExtensionsExtensions.cs
+++ b/src/dotnet-serve/DefaultExtensions/DefaultExtensionsExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Options;
+
+namespace McMaster.DotNet.Server.DefaultExtensions
+{    
+    public static class DefaultExtensionsExtensions
+    {
+        public static IApplicationBuilder UseDefaultExtensions(this IApplicationBuilder app, DefaultExtensionsOptions options)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            return app.UseMiddleware<DefaultExtensionsMiddleware>(Options.Create(options));
+        }
+    }
+}

--- a/src/dotnet-serve/DefaultExtensions/DefaultExtensionsMiddleware.cs
+++ b/src/dotnet-serve/DefaultExtensions/DefaultExtensionsMiddleware.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace McMaster.DotNet.Server.DefaultExtensions
+{
+    public class DefaultExtensionsMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly IFileProvider _fileProvider;
+        private readonly DefaultExtensionsOptions _options;
+        private readonly ILogger _logger;
+
+        public DefaultExtensionsMiddleware(RequestDelegate next, IHostingEnvironment hostingEnv, IOptions<DefaultExtensionsOptions> options, ILoggerFactory loggerFactory)
+        {
+            if (next == null)
+            {
+                throw new ArgumentNullException(nameof(next));
+            }
+
+            if (hostingEnv == null)
+            {
+                throw new ArgumentNullException(nameof(hostingEnv));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _next = next;
+            _fileProvider = hostingEnv.WebRootFileProvider;
+            _options = options.Value;
+            _logger = loggerFactory.CreateLogger<DefaultExtensionsMiddleware>();
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            if (IsGetOrHeadMethod(context.Request.Method)
+                && !PathEndsInSlash(context.Request.Path))
+            {
+                // Check if there's a file with a matched extension, and rewrite the request if found
+                foreach (string extension in _options.Extensions)
+                {
+                    string filePath = context.Request.Path.ToString() + extension;
+                    IFileInfo fileInfo = _fileProvider.GetFileInfo(filePath);
+                    if (fileInfo != null && fileInfo.Exists)
+                    {
+                        _logger.LogInformation($"Rewriting extensionless path to {filePath}");
+                        context.Request.Path = new PathString(filePath);
+                        break;
+                    }
+                }
+            }
+            await _next(context);
+        }
+        
+        private static bool IsGetOrHeadMethod(string method) =>
+            HttpMethods.IsGet(method) || HttpMethods.IsHead(method);
+
+        private static bool PathEndsInSlash(PathString path) =>
+            path.Value.EndsWith("/", StringComparison.Ordinal);
+    }
+}
+

--- a/src/dotnet-serve/DefaultExtensions/DefaultExtensionsOptions.cs
+++ b/src/dotnet-serve/DefaultExtensions/DefaultExtensionsOptions.cs
@@ -1,0 +1,8 @@
+namespace McMaster.DotNet.Server.DefaultExtensions
+{
+    public class DefaultExtensionsOptions
+    {        
+        public string[] Extensions { get; set; }
+    }
+}
+

--- a/src/dotnet-serve/Startup.cs
+++ b/src/dotnet-serve/Startup.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
+using McMaster.DotNet.Server.DefaultExtensions;
 using McMaster.DotNet.Server.RazorPages;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -55,9 +56,10 @@ namespace McMaster.DotNet.Server
                 _sourceProvider.Initialize();
             }
 
-            if (!string.IsNullOrEmpty(_options.PathBase))
+            var pathBase = _options.GetPathBase();
+            if (!string.IsNullOrEmpty(pathBase))
             {
-                app.Map(_options.PathBase, ConfigureFileServer);
+                app.Map(pathBase, ConfigureFileServer);
             }
             else
             {
@@ -66,7 +68,16 @@ namespace McMaster.DotNet.Server
         }
 
         private void ConfigureFileServer(IApplicationBuilder app)
-        {
+        {          
+            var defaultExtensions = _options.GetDefaultExtensions();  
+            if(defaultExtensions != null && defaultExtensions.Length > 0)
+            {
+                app.UseDefaultExtensions(new DefaultExtensionsOptions
+                {
+                    Extensions = defaultExtensions
+                });
+            }
+
             app.UseFileServer(new FileServerOptions
             {
                 EnableDefaultFiles = true,


### PR DESCRIPTION
Resolves #1. The `.UseDefaultExtensions` will need to be copied inside the `.Map` or into the common `IApplicationBuilder` configuration method once #3 is merged.