### PR TITLE
 [#16] Add support for file extension MIME mapping 

### DIFF
--- a/src/dotnet-serve/CommandLineOptions.cs
+++ b/src/dotnet-serve/CommandLineOptions.cs
@@ -103,8 +103,8 @@ namespace McMaster.DotNet.Serve
         [Option("--pfx-pwd", Description = "The password to open the certificate file. (Optional)")]
         public virtual string CertificatePassword { get; }
 
-        [Option("-m|--mime <EXT>=<MIME>", CommandOptionType.MultipleValue, Description = "Add a mapping from file extension to MIME type.")]
-        [RegularExpression(@"^([^=]+)=([^=]+)$", ErrorMessage = "MIME mappings must have the form: ext=mime/type")]
+        [Option("-m|--mime <EXT>=<MIME>", CommandOptionType.MultipleValue, Description = "Add a mapping from file extension to MIME type. Empty MIME removes a mapping.")]
+        [RegularExpression(@"^([^=]+)=([^=]*)$", ErrorMessage = "MIME mappings must have the form: ext=mime/type")]
         public string[] MimeMappings { get; }
 
         // Internal, experimental flag. If you found this, it may break in the future.
@@ -144,7 +144,7 @@ namespace McMaster.DotNet.Serve
                     {
                         ext = "." + ext;
                     }
-                    var mime = s.Substring(sepIndex + 1);
+                    var mime = sepIndex == s.Length - 1 ? null : s.Substring(sepIndex + 1);
                     return (ext, mime);
                 })
                 .ToDictionary(p => p.ext, p => p.mime, StringComparer.OrdinalIgnoreCase);

--- a/src/dotnet-serve/CommandLineOptions.cs
+++ b/src/dotnet-serve/CommandLineOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Nate McMaster.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -102,6 +103,10 @@ namespace McMaster.DotNet.Serve
         [Option("--pfx-pwd", Description = "The password to open the certificate file. (Optional)")]
         public virtual string CertificatePassword { get; }
 
+        [Option("-m|--mime <EXT>=<MIME>", CommandOptionType.MultipleValue, Description = "Add a mapping from file extension to MIME type.")]
+        [RegularExpression(@"^([^=]+)=([^=]+)$", ErrorMessage = "MIME mappings must have the form: ext=mime/type")]
+        public string[] MimeMappings { get; }
+
         // Internal, experimental flag. If you found this, it may break in the future.
         // I'm not supporting it yet becuase these files will still who up directory browser.
         [Option("--exclude-file", Description = "A file to prevent from being served.", ShowInHelpText = false)]
@@ -128,6 +133,21 @@ namespace McMaster.DotNet.Serve
                     ? new[] { ".html", ".htm" }
                     : DefaultExtensions.Extensions.Split(',').Select(x => x.StartsWith('.') ? x : "." + x).ToArray()
                 : null;
+
+        public IDictionary<string, string> GetMimeMappings() =>
+            MimeMappings
+                ?.Select(s =>
+                {
+                    var sepIndex = s.IndexOf('=');
+                    var ext = s.Substring(0, sepIndex);
+                    if (!ext.StartsWith('.'))
+                    {
+                        ext = "." + ext;
+                    }
+                    var mime = s.Substring(sepIndex + 1);
+                    return (ext, mime);
+                })
+                .ToDictionary(p => p.ext, p => p.mime, StringComparer.OrdinalIgnoreCase);
 
         private static string GetVersion()
             => typeof(CommandLineOptions).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;

--- a/src/dotnet-serve/Startup.cs
+++ b/src/dotnet-serve/Startup.cs
@@ -87,11 +87,22 @@ namespace McMaster.DotNet.Serve
                 });
             }
 
+            var contentTypeProvider = new FileExtensionContentTypeProvider();
             var mimeMappings = _options.GetMimeMappings();
-            var contentTypeProvider =
-                mimeMappings != null && mimeMappings.Count > 0
-                    ? new FileExtensionContentTypeProvider(mimeMappings)
-                    : new FileExtensionContentTypeProvider();
+            if (mimeMappings != null)
+            {
+                foreach (var mapping in mimeMappings)
+                {
+                    if (mapping.Value == null)
+                    {
+                        contentTypeProvider.Mappings.Remove(mapping.Key);
+                    }
+                    else
+                    {
+                        contentTypeProvider.Mappings[mapping.Key] = mapping.Value;
+                    }
+                }
+            }
 
             app.UseFileServer(new FileServerOptions
             {

--- a/src/dotnet-serve/Startup.cs
+++ b/src/dotnet-serve/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace McMaster.DotNet.Serve
@@ -86,6 +87,12 @@ namespace McMaster.DotNet.Serve
                 });
             }
 
+            var mimeMappings = _options.GetMimeMappings();
+            var contentTypeProvider =
+                mimeMappings != null && mimeMappings.Count > 0
+                    ? new FileExtensionContentTypeProvider(mimeMappings)
+                    : new FileExtensionContentTypeProvider();
+
             app.UseFileServer(new FileServerOptions
             {
                 EnableDefaultFiles = true,
@@ -93,6 +100,7 @@ namespace McMaster.DotNet.Serve
                 StaticFileOptions =
                 {
                     ServeUnknownFileTypes = true,
+                    ContentTypeProvider = contentTypeProvider
                 },
             });
         }

--- a/test/dotnet-serve.Tests/DotNetServe.cs
+++ b/test/dotnet-serve.Tests/DotNetServe.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
@@ -95,6 +96,7 @@ namespace McMaster.DotNet.Serve.Tests
             int? port = default,
             bool enableTls = false,
             string certPassword = null,
+            string[] mimeMap = null,
             ITestOutputHelper output = null)
         {
             var psi = new ProcessStartInfo
@@ -133,6 +135,15 @@ namespace McMaster.DotNet.Serve.Tests
             {
                 psi.ArgumentList.Add("--pfx-pwd");
                 psi.ArgumentList.Add(certPassword);
+            }
+
+            if (mimeMap != null)
+            {
+                foreach (var mapping in mimeMap)
+                {
+                    psi.ArgumentList.Add("-m");
+                    psi.ArgumentList.Add(mapping);
+                }
             }
 
             var process = new Process

--- a/test/dotnet-serve.Tests/MimeTests.cs
+++ b/test/dotnet-serve.Tests/MimeTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace McMaster.DotNet.Serve.Tests
+{
+    public class MimeTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public MimeTests(ITestOutputHelper output)
+        {
+            this._output = output;
+        }
+
+        [Theory]
+        // Check that *.mytxt has no default mapping.
+        [InlineData("/file.mytxt", "contents of file.mytxt\n", null,                    "notmytxt=application/x-notmytxt")]
+        // Add a mapping without prefix dot.
+        [InlineData("/file.mytxt", "contents of file.mytxt\n", "application/x-mytxt",   "mytxt=application/x-mytxt")]
+        // Add a mapping with prefix dot.
+        [InlineData("/file.mytxt", "contents of file.mytxt\n", "application/x-mytxt",   ".mytxt=application/x-mytxt")]
+        // Add several mappings.
+        [InlineData("/file.mytxt", "contents of file.mytxt\n", "application/x-mytxt",   "mytxt=application/x-mytxt", "notmytxt=application/x-notmytxt")]
+        // Check that *.js has a default mapping.
+        [InlineData("/file.js",    "contents_of_file.js\n",    "application/javascript")]
+        // Override a default mapping.
+        [InlineData("/file.js",    "contents_of_file.js\n",    "application/my-js",     "js=application/my-js")]
+        // Remove a default mapping.
+        [InlineData("/file.js",    "contents_of_file.js\n",    null,                    "js=")]
+        public async Task ItAppliesMimeMappings(string file, string expectedContents, string expectedMime, params string[] mimeMap)
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "TestAssets", "Mime");
+            using (var ds = DotNetServe.Start(path,
+                output: _output,
+                mimeMap: mimeMap))
+            {
+                var resp = await ds.Client.GetWithRetriesAsync(file);
+                if (expectedMime == null)
+                {
+                    Assert.Null(resp.Content.Headers.ContentType);
+                }
+                else
+                {
+                    Assert.Equal(resp.Content.Headers.ContentType.MediaType, expectedMime);
+                }
+                var respTxt = await resp.Content.ReadAsStringAsync();
+                Assert.Equal(respTxt, expectedContents);
+            }
+        }
+    }
+}

--- a/test/dotnet-serve.Tests/TestAssets/Mime/file.js
+++ b/test/dotnet-serve.Tests/TestAssets/Mime/file.js
@@ -1,0 +1,1 @@
+contents_of_file.js

--- a/test/dotnet-serve.Tests/TestAssets/Mime/file.mytxt
+++ b/test/dotnet-serve.Tests/TestAssets/Mime/file.mytxt
@@ -1,0 +1,1 @@
+contents of file.mytxt


### PR DESCRIPTION
Resolves #16. This adds a new multiple command line argument: `-m|--mime <EXT>=<MIME>`.

If `MIME` is non-empty, this creates a mapping from `*.EXT` to MIME type `MIME`.

If `MIME` is empty, this removes the existing mapping for `*.EXT`.

Example use:

    dotnet serve -m .wasm=application/wasm -m myext=application/x-myfiletype -m js=

The above adds MIME types for `*.wasm` and `*.myext` and removes the default MIME type for `*.js`.