### PR TITLE
Force LF for the test file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -50,3 +50,4 @@
 *.sln text=auto eol=crlf
 
 *.sh eol=lf
+test/dotnet-serve.Tests/TestAssets/Mime/file.js eol=lf


### PR DESCRIPTION
When I checked out the master branch, the tests failed. You're 
explicitly expecting `\n` line endings, and git normalises them
to `\n\r` on Windows. This forces the line ending for that file.