### PR TITLE
Add -z|--gzip option to enable output compression

### DIFF
--- a/src/dotnet-serve/CommandLineOptions.cs
+++ b/src/dotnet-serve/CommandLineOptions.cs
@@ -116,7 +116,7 @@ namespace McMaster.DotNet.Serve
         [Option("--exclude-file", Description = "A file to prevent from being served.", ShowInHelpText = false)]
         public List<string> ExcludedFiles { get; } = new List<string>();
 
-        [Option("-Z|--gzip", Description = "Enable gzip compression")]
+        [Option("-z|--gzip", Description = "Enable gzip compression")]
         public bool UseGzip { get; }
 
         public string GetPathBase()

--- a/src/dotnet-serve/CommandLineOptions.cs
+++ b/src/dotnet-serve/CommandLineOptions.cs
@@ -116,6 +116,9 @@ namespace McMaster.DotNet.Serve
         [Option("--exclude-file", Description = "A file to prevent from being served.", ShowInHelpText = false)]
         public List<string> ExcludedFiles { get; } = new List<string>();
 
+        [Option("-Z|--gzip", Description = "Enable gzip compression")]
+        public bool UseGzip { get; }
+
         public string GetPathBase()
         {
             if (string.IsNullOrEmpty(PathBase))

--- a/src/dotnet-serve/Startup.cs
+++ b/src/dotnet-serve/Startup.cs
@@ -36,6 +36,11 @@ namespace McMaster.DotNet.Serve
                 .Configure<KeyManagementOptions>(o => o.XmlRepository = new EphemeralXmlRepository())
                 .AddSingleton<IKeyManager, KeyManager>()
                 .AddSingleton<IAuthorizationPolicyProvider, NullAuthPolicyProvider>();
+
+            if (_options.UseGzip)
+            {
+                services.AddResponseCompression();
+            }
         }
 
         public void Configure(IApplicationBuilder app)
@@ -112,6 +117,11 @@ namespace McMaster.DotNet.Serve
                 {
                     Headers = headers
                 });
+            }
+
+            if (_options.UseGzip)
+            {
+                app.UseResponseCompression();
             }
 
             app.UseFileServer(new FileServerOptions

--- a/test/dotnet-serve.Tests/DotNetServe.cs
+++ b/test/dotnet-serve.Tests/DotNetServe.cs
@@ -98,7 +98,8 @@ namespace McMaster.DotNet.Serve.Tests
             string certPassword = null,
             string[] mimeMap = null,
             string[] headers = null,
-            ITestOutputHelper output = null)
+            ITestOutputHelper output = null,
+            bool useGzip = false)
         {
             var psi = new ProcessStartInfo
             {
@@ -154,6 +155,11 @@ namespace McMaster.DotNet.Serve.Tests
                     psi.ArgumentList.Add("-h");
                     psi.ArgumentList.Add(header);
                 }
+            }
+
+            if (useGzip)
+            {
+                psi.ArgumentList.Add("-Z");
             }
 
             var process = new Process

--- a/test/dotnet-serve.Tests/DotNetServe.cs
+++ b/test/dotnet-serve.Tests/DotNetServe.cs
@@ -159,7 +159,7 @@ namespace McMaster.DotNet.Serve.Tests
 
             if (useGzip)
             {
-                psi.ArgumentList.Add("-Z");
+                psi.ArgumentList.Add("-z");
             }
 
             var process = new Process

--- a/test/dotnet-serve.Tests/GzipTests.cs
+++ b/test/dotnet-serve.Tests/GzipTests.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace McMaster.DotNet.Serve.Tests
+{
+    public class GzipTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public GzipTests(ITestOutputHelper output)
+        {
+            this._output = output;
+        }
+
+        [Fact]
+        public async Task ItCompressesOutput()
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "TestAssets", "Mime");
+            using (var ds = DotNetServe.Start(path,
+                output: _output,
+                useGzip: true
+            ))
+            {
+                ds.Client.DefaultRequestHeaders.Add("Accept-Encoding", "gzip, deflate");
+                var resp = await ds.Client.GetWithRetriesAsync("file.js");
+                Assert.Equal("gzip", resp.Content.Headers.ContentEncoding.First());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/natemcmaster/dotnet-serve/issues/13.

Usage:

```
dotnet-serve -Z
```