### PR TITLE
Update to 1.7 and always produce a package version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.6.0</VersionPrefix>
+    <VersionPrefix>1.7.0</VersionPrefix>
     <VersionSuffix>build</VersionSuffix>
     <IncludePreReleaseLabelInPackageVersion Condition="'$(IsStableBuild)' != 'true'">true</IncludePreReleaseLabelInPackageVersion>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$([MSBuild]::ValueOrDefault($(BUILD_NUMBER), 0))</BuildNumber>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,15 +27,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.7.0</VersionPrefix>
-    <VersionSuffix>build</VersionSuffix>
-    <IncludePreReleaseLabelInPackageVersion Condition="'$(IsStableBuild)' != 'true'">true</IncludePreReleaseLabelInPackageVersion>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$([MSBuild]::ValueOrDefault($(BUILD_NUMBER), 0))</BuildNumber>
-    <VersionSuffix>$(VersionSuffix).$(BuildNumber)</VersionSuffix>
+    <VersionPrefix>1.7.$(BuildNumber)</VersionPrefix>
     <SourceRevisionId Condition="'$(SourceRevisionId)' == ''">$(BUILD_SOURCEVERSION)</SourceRevisionId>
-    <PackageVersion>$(VersionPrefix)</PackageVersion>
-    <PackageVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">$(PackageVersion)-$(VersionSuffix)</PackageVersion>
-    <InformationalVersion Condition="'$(SourceRevisionId)' != ''">$(PackageVersion)+$(SourceRevisionId)</InformationalVersion>
     <PackageDescription>$(Description)</PackageDescription>
     <PackageDescription Condition="'$(SourceRevisionId)' != ''">$(PackageDescription)
 

--- a/src/dotnet-serve/releasenotes.props
+++ b/src/dotnet-serve/releasenotes.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <PackageReleaseNotes Condition=" '$(VersionPrefix)' == '1.7.0' ">
+    <PackageReleaseNotes Condition=" $(VersionPrefix.StartsWith('1.7.')) ">
 Improvement:
 * @ansariabr: add support for a --cors options which can be used to enable CORS and OPTIONS requests (#45)
     </PackageReleaseNotes>
@@ -28,8 +28,5 @@ New feature:
 Deprecated feature:
 * Remove `--razor`. This was a prototype, but due to pending deprecation of some Razor APIs, this feature won't work in the future anyways. See https://github.com/aspnet/Announcements/issues/312
     </PackageReleaseNotes>
-    <PackageReleaseNotes>$(PackageReleaseNotes)
-
-See $(PackageProjectUrl)/blob/master/CHANGELOG.md#v$(VersionPrefix.Replace('.','')) for release notes.</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/src/dotnet-serve/releasenotes.props
+++ b/src/dotnet-serve/releasenotes.props
@@ -1,5 +1,9 @@
 <Project>
   <PropertyGroup>
+    <PackageReleaseNotes Condition=" '$(VersionPrefix)' == '1.7.0' ">
+Improvement:
+* @ansariabr: add support for a --cors options which can be used to enable CORS and OPTIONS requests (#45)
+    </PackageReleaseNotes>
     <PackageReleaseNotes Condition=" '$(VersionPrefix)' == '1.6.0' ">
 Improvement:
 * @pranavkm: fix `dotnet-serve -p 0`  (#40)


### PR DESCRIPTION
Workaround for https://github.com/dotnet/sdk/issues/9037. Also, this just simplifies the effort to build a release.