### PR TITLE
Fix for bug #57 - consider latest expiring certificate

### DIFF
--- a/src/dotnet-serve/Security/CertificateLoader.cs
+++ b/src/dotnet-serve/Security/CertificateLoader.cs
@@ -159,7 +159,18 @@ namespace McMaster.DotNet.Serve
 
             if (certs.Count > 1)
             {
-                throw new InvalidOperationException($"Ambiguous certficiate match. Multiple certificates found with extension '{AspNetHttpsOid}' ({AspNetHttpsOidFriendlyName}).");
+                // Returning a certificate which has the latest expiry date
+                var expiryDate = DateTime.MinValue;
+                var thumbprint = string.Empty;
+                foreach (var certificate in certs)
+                {
+                    if (certificate.NotAfter > expiryDate)
+                    {
+                        expiryDate = certificate.NotAfter;
+                        thumbprint = certificate.Thumbprint;
+                    }
+                }
+                return certs.Find(X509FindType.FindByThumbprint, thumbprint, validOnly: false)[0];
             }
 
             return null;


### PR DESCRIPTION
Consider latest expiring certificate in case of multiple ASP.Net Core development certificates.
Unable to add tests since the method LoadDeveloperCertificate() is accessing the machines certificate store.