### PR TITLE
Add support for reading/writing arguments from/to .netconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Options:
   -z|--gzip                            Enable gzip compression
   -b|--brotli                          Enable brotli compression (requires .NET Core 3+)
   -c|--cors                            Enable CORS (It will enable CORS for all origin and all methods)
+  --save-options                       Save specified options to .netconfig for subsequent runs.
   -?|--help                            Show help information
 ```
 
@@ -106,3 +107,44 @@ When serving on 'localhost', dotnet-serve will discover and use when you run:
 ```
 dotnet serve -S
 ```
+
+## Reusing options with .netconfig
+
+`dotnet-serve` supports reading and saving options using [dotnet-config](https://dotnetconfig.org/), 
+which provides hierarchical inherited configuration for any .NET tool. This means you can save your 
+frequently used options to `.netconfig` so you don't need to specify them every time and for every 
+folder you serve across your machine.
+
+To save the options used in a particular run to the current directory's `.netconfig`, just append 
+`--save-options`:
+
+```
+dotnet serve -p 8080 --gzip --cors --quiet --save-options
+```
+
+After running that command, a new `.netconfig` will be created (if there isn't one already there) 
+with the following section for `dotnet-serve`:
+
+```
+[serve]
+	port = 8000
+	quiet
+	gzip
+	cors
+	header = X-My-Option: foo
+	header = X-Another: bar
+```
+
+(note multiple `header`, `mime` type mappings and `exclude-file` entries can be provided as
+individual variables)
+
+You can place those settings in any parent folder and it will be reused across all descendent 
+folders, or they can also be saved to the global (user profile) or system locations. To easily 
+configure these options at those levels, use the `dotnet-config` tool itself:
+
+```
+dotnet config --global --set serve.port 8000
+```
+
+This will default the port to `8000` whenever a port is not specified in the command line. You 
+can open the saved `.netconfig` at `%USERPROFILE%\.netconfig` or `~/.netconfig`.

--- a/src/dotnet-serve/.netconfig
+++ b/src/dotnet-serve/.netconfig
@@ -1,0 +1,9 @@
+[serve]
+	header = x-frame-options: SAMEORIGIN
+	mime = .netconfig=text/plain
+	mime = .cs=text/plain
+	mime = .vb=text/plain
+	mime = .csproj=text/xml
+	exclude-file = dotnet-serve.csproj
+	exclude-file = releasenotes.props
+	open-browser

--- a/src/dotnet-serve/CommandLineOptions.cs
+++ b/src/dotnet-serve/CommandLineOptions.cs
@@ -24,14 +24,14 @@ namespace McMaster.DotNet.Serve
 
         [Option("-d|--directory <DIR>", Description = "The root directory to serve. [Current directory]")]
         [DirectoryExists]
-        public string Directory { get; }
+        public string Directory { get; internal set; }
 
         [Option(Description = "Open a web browser when the server starts. [false]")]
-        public bool OpenBrowser { get; }
+        public bool? OpenBrowser { get; internal set; }
 
         [Option(Description = "Port to use [8080]. Use 0 for a dynamic port.")]
         [Range(0, 65535, ErrorMessage = "Invalid port. Ports must be in the range of 0 to 65535.")]
-        public int Port { get; } = 8080;
+        public int? Port { get; internal set; }
 
         [Option("-a|--address <ADDRESS>", Description = "Address to use [127.0.0.1]")]
         public IPAddress[] Addresses { get; }
@@ -43,14 +43,14 @@ namespace McMaster.DotNet.Serve
         public (bool HasValue, string Extensions) DefaultExtensions { get; }
 
         [Option(Description = "Show less console output.")]
-        public bool Quiet { get; }
+        public bool? Quiet { get; internal set; }
 
         [Option(Description = "Show more console output.")]
-        public bool Verbose { get; }
+        public bool? Verbose { get; internal set; }
 
         [Option("-h|--headers <HEADER_AND_VALUE>", CommandOptionType.MultipleValue, Description = "A header to return with all file/directory responses. e.g. -h \"X-XSS-Protection: 1; mode=block\"")]
         [RegularExpression(@"^([^:]+):([^:]*)$", ErrorMessage = "Headers must have the form: HEADER:VALUE")]
-        public string[] Headers { get; }
+        public string[] Headers { get; internal set; }
 
         [Option("--log <LEVEL>", Description = "For advanced diagnostics.", ShowInHelpText = false)]
         public LogLevel MinLogLevel
@@ -62,12 +62,12 @@ namespace McMaster.DotNet.Serve
                     return _logLevel.Value;
                 }
 
-                if (Quiet)
+                if (Quiet == true)
                 {
                     return LogLevel.Error;
                 }
 
-                if (Verbose)
+                if (Verbose == true)
                 {
                     return LogLevel.Debug;
                 }
@@ -89,27 +89,29 @@ namespace McMaster.DotNet.Serve
 
                 return !string.IsNullOrEmpty(CertPfxPath) || !string.IsNullOrEmpty(CertPemPath);
             }
-            private set => _useTls = value;
+            internal set => _useTls = value;
         }
+
+        internal bool UseTlsSpecified => _useTls.HasValue;
 
         [Option("--cert", Description = "A PEM encoded certificate file to use for HTTPS connections.\nDefaults to file in current directory named '" + CertificateLoader.DefaultCertPemFileName + "'")]
         [FileExists]
-        public string CertPemPath { get; }
+        public string CertPemPath { get; internal set; }
 
         [Option("--key", Description = "A PEM encoded private key to use for HTTPS connections.\nDefaults to file in current directory named '" + CertificateLoader.DefaultPrivateKeyFileName + "'")]
         [FileExists]
-        public string PrivateKeyPath { get; }
+        public string PrivateKeyPath { get; internal set; }
 
         [Option("--pfx", Description = "A PKCS#12 certificate file to use for HTTPS connections.\nDefaults to file in current directory named '" + CertificateLoader.DefaultCertPfxFileName + "'")]
         [FileExists]
-        public string CertPfxPath { get; }
+        public string CertPfxPath { get; internal set; }
 
         [Option("--pfx-pwd", Description = "The password to open the certificate file. (Optional)")]
-        public virtual string CertificatePassword { get; }
+        public virtual string CertificatePassword { get; internal set; }
 
         [Option("-m|--mime <MAPPING>", CommandOptionType.MultipleValue, Description = "Add a mapping from file extension to MIME type. Empty MIME removes a mapping.\nExpected format is <EXT>=<MIME>.")]
         [RegularExpression(@"^([^=]+)=([^=]*)$", ErrorMessage = "MIME mappings must have the form: ext=mime/type")]
-        public string[] MimeMappings { get; }
+        public string[] MimeMappings { get; internal set; }
 
         // Internal, experimental flag. If you found this, it may break in the future.
         // I'm not supporting it yet because these files will still show up directory browser.
@@ -117,15 +119,21 @@ namespace McMaster.DotNet.Serve
         public List<string> ExcludedFiles { get; } = new List<string>();
 
         [Option("-z|--gzip", Description = "Enable gzip compression")]
-        public bool UseGzip { get; }
+        public bool? UseGzip { get; internal set; }
 
 #if !NETCOREAPP2_1
         [Option("-b|--brotli", Description = "Enable brotli compression")]
 #endif
-        public bool UseBrotli { get; }
+        public bool? UseBrotli { get; internal set; }
 
         [Option("-c|--cors",Description ="Enable CORS (It will enable CORS for all origin and all methods)")]
-        public bool EnableCors { get; }
+        public bool? EnableCors { get; internal set; }
+
+        [Option("--save-options", Description = "Save specified options to .netconfig for subsequent runs.")]
+        public bool SaveOptions { get; }
+
+        [Option("--config-file", Description = "Use the given .netconfig file.")]
+        public string ConfigFile { get; }
 
         public string GetPathBase()
         {

--- a/src/dotnet-serve/Program.cs
+++ b/src/dotnet-serve/Program.cs
@@ -3,7 +3,12 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using McMaster.Extensions.CommandLineUtils;
+using DotNetConfig;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Collections.Generic;
 
 namespace McMaster.DotNet.Serve
 {
@@ -12,7 +17,11 @@ namespace McMaster.DotNet.Serve
         public static int Main(string[] args)
         {
             DebugHelper.HandleDebugSwitch(ref args);
+            return new Program().Run(args);
+        }
 
+        internal int Run(params string[] args)
+        {
             try
             {
                 using var app = new CommandLineApplication<CommandLineOptions>();
@@ -20,17 +29,171 @@ namespace McMaster.DotNet.Serve
                 app.Conventions.UseDefaultConventions();
                 app.OnExecuteAsync(async ct =>
                 {
-                    var server = new SimpleServer(app.Model, PhysicalConsole.Singleton, Directory.GetCurrentDirectory());
-                    return await server.RunAsync(ct);
+                    // NOTE: this isn't very elegant, but moving this logic
+                    // down to the CommandLineUtils level proved quite challenging
+                    // and potentially not that useful.
+                    var config = Config.Build(app.Model.ConfigFile).GetSection("serve");
+
+                    ReadConfig(config, app.Model);
+                    if (app.Model.SaveOptions)
+                    {
+                        WriteConfig(config, app.Model);
+                    }
+
+                    return await OnRunAsync(app.Model, ct);
                 });
+                app.OnValidationError(r => Error(r.ErrorMessage));
                 return app.Execute(args);
             }
             catch (Exception ex)
             {
-                Console.ForegroundColor = ConsoleColor.Red;
-                Console.Error.WriteLine("Unexpected error: " + ex.ToString());
-                Console.ResetColor();
+                Error("Unexpected error: " + ex.ToString());
                 return 2;
+            }
+        }
+
+        public List<string> Errors { get; } = new List<string>();
+
+        void Error(string message)
+        {
+            Errors.Add(message);
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.Error.WriteLine(message);
+            Console.ResetColor();
+        }
+
+        protected virtual Task<int> OnRunAsync(CommandLineOptions options, CancellationToken ct)
+        {
+            var server = new SimpleServer(options, PhysicalConsole.Singleton, Directory.GetCurrentDirectory());
+            return server.RunAsync(ct);
+        }
+
+        static void ReadConfig(ConfigSection config, CommandLineOptions model)
+        {
+            model.Port ??= (int?)config.GetNumber("port");
+            model.Directory ??= config.GetString("directory");
+            model.OpenBrowser ??= config.GetBoolean("open-browser"); 
+            model.Quiet ??= config.GetBoolean("quiet");
+            model.Verbose ??= config.GetBoolean("verbose");
+            model.CertPemPath ??= config.GetString("cert");
+            model.PrivateKeyPath ??= config.GetString("key");
+            model.CertPfxPath ??= config.GetString("pfx");
+            model.CertificatePassword ??= config.GetString("pfx-pwd");
+            model.UseGzip ??= config.GetBoolean("gzip");
+            model.UseBrotli ??= config.GetBoolean("brotli");
+            model.EnableCors ??= config.GetBoolean("cors");
+
+            if (!model.UseTlsSpecified && config.TryGetBoolean("tls", out var tls))
+            {
+                model.UseTls = tls;
+            }
+
+            var headers = config.GetAll("header").Select(e => e.RawValue).ToArray();
+            if (headers.Length > 0)
+            {
+                if (model.Headers == null)
+                {
+                    model.Headers = headers;
+                }
+                else
+                {
+                    var all = new string[model.Headers.Length + headers.Length];
+                    model.Headers.CopyTo(all, 0);
+                    headers.CopyTo(all, model.Headers.Length);
+                    model.Headers = all;
+                }
+            }
+
+            var mime = config.GetAll("mime").Select(e => e.RawValue).ToArray();
+            if (mime.Length > 0)
+            {
+                if (model.MimeMappings == null)
+                {
+                    model.MimeMappings = mime;
+                }
+                else
+                {
+                    var all = new string[model.MimeMappings.Length + mime.Length];
+                    model.MimeMappings.CopyTo(all, 0);
+                    mime.CopyTo(all, model.MimeMappings.Length);
+                    model.MimeMappings = all;
+                }
+            }
+
+            model.ExcludedFiles.AddRange(
+                config.GetAll("exclude-file").Select(x => x.RawValue));
+        }
+
+        static void WriteConfig(ConfigSection config, CommandLineOptions model)
+        {
+            if (model.Port != null)
+            {
+                config.SetNumber("port", model.Port.GetValueOrDefault());
+            }
+            if (model.Directory != null)
+            {
+                config.SetString("directory", model.Directory);
+            }
+            if (model.OpenBrowser != null)
+            {
+                config.SetBoolean("open-browser", model.OpenBrowser.Value);
+            }
+            if (model.Quiet != null)
+            {
+                config.SetBoolean("quiet", model.Quiet.Value);
+            }
+            if (model.Verbose != null)
+            {
+                config.SetBoolean("verbose", model.Verbose.Value);
+            }
+            if (model.CertPemPath != null)
+            {
+                config.SetString("cert", model.CertPemPath);
+            }
+            if (model.PrivateKeyPath != null)
+            {
+                config.SetString("key", model.PrivateKeyPath);
+            }
+            if (model.CertPfxPath != null)
+            {
+                config.SetString("pfx", model.CertPfxPath);
+            }
+            if (model.CertificatePassword != null)
+            {
+                config.SetString("pfx-pwd", model.CertificatePassword);
+            }
+            if (model.UseGzip != null)
+            {
+                config.SetBoolean("gzip", model.UseGzip.Value);
+            }
+            if (model.UseBrotli != null)
+            {
+                config.SetBoolean("brotli", model.UseBrotli.Value);
+            }
+            if (model.EnableCors != null)
+            {
+                config.SetBoolean("cors", model.EnableCors.Value);
+            }
+
+            if (model.Headers != null)
+            {
+                foreach (var header in model.Headers)
+                {
+                    config.AddString("header", header);
+                }
+            }
+
+            if (model.MimeMappings != null)
+            {
+                foreach (var mime in model.MimeMappings)
+                {
+                    config.AddString("mime", mime);
+                }
+            }
+
+            foreach (var excluded in model.ExcludedFiles)
+            {
+                config.AddString("exclude-file", excluded);
             }
         }
     }

--- a/src/dotnet-serve/Properties/launchSettings.json
+++ b/src/dotnet-serve/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "dotnet-serve": {
       "commandName": "Project",
-      "commandLineArgs": "-o -p 5043 -h \"X-XSS-Protection: 1; mode=block\" -h \"x-frame-options: SAMEORIGIN\" ",
+      "commandLineArgs": "-p 5043 -h \"X-XSS-Protection: 1; mode=block\" ",
       "workingDirectory": "$(MSBuildProjectDirectory)"
     }
   }

--- a/src/dotnet-serve/SimpleServer.cs
+++ b/src/dotnet-serve/SimpleServer.cs
@@ -32,8 +32,8 @@ namespace McMaster.DotNet.Serve
             _currentDirectory = currentDirectory;
             _reporter = new ConsoleReporter(console)
             {
-                IsQuiet = options.Quiet,
-                IsVerbose = options.Verbose,
+                IsQuiet = options.Quiet == true,
+                IsVerbose = options.Verbose == true,
             };
         }
 
@@ -73,20 +73,20 @@ namespace McMaster.DotNet.Serve
                 {
                     if (_options.ShouldUseLocalhost())
                     {
-                        if (port == 0)
+                        if (port.GetValueOrDefault() == 0)
                         {
                             o.ListenAnyIP(0, ConfigureHttps);
                         }
                         else
                         {
-                            o.ListenLocalhost(port, ConfigureHttps);
+                            o.ListenLocalhost(port.GetValueOrDefault(), ConfigureHttps);
                         }
                     }
                     else
                     {
                         foreach (var a in _options.Addresses)
                         {
-                            o.Listen(a, port, ConfigureHttps);
+                            o.Listen(a, port.GetValueOrDefault(), ConfigureHttps);
                         }
                     }
                 })
@@ -127,7 +127,7 @@ namespace McMaster.DotNet.Serve
             _console.WriteLine("");
             _console.WriteLine("Press CTRL+C to exit");
 
-            if (_options.OpenBrowser)
+            if (_options.OpenBrowser == true)
             {
                 var url = NormalizeToLoopbackAddress(addresses.Addresses.First());
 

--- a/src/dotnet-serve/Startup.cs
+++ b/src/dotnet-serve/Startup.cs
@@ -41,7 +41,7 @@ namespace McMaster.DotNet.Serve
                 .AddSingleton<IKeyManager, KeyManager>()
                 .AddSingleton<IAuthorizationPolicyProvider, NullAuthPolicyProvider>();
 
-            if (_options.EnableCors)
+            if (_options.EnableCors == true)
             {
                 services.AddCors();
             }
@@ -50,14 +50,14 @@ namespace McMaster.DotNet.Serve
             {
                 options.Providers.Clear();
 
-                if (_options.UseGzip)
+                if (_options.UseGzip == true)
                 {
                     options.Providers.Add<GzipCompressionProvider>();
                 }
 
 
 #if NETCOREAPP3_0
-                if (_options.UseBrotli)
+                if (_options.UseBrotli == true)
                 {
                     options.Providers.Add<BrotliCompressionProvider>();
                 }
@@ -67,7 +67,7 @@ namespace McMaster.DotNet.Serve
 
         public void Configure(IApplicationBuilder app)
         {
-            if (_options.EnableCors)
+            if (_options.EnableCors == true)
             {
                 app.UseCors(corsPolicy =>
                 {
@@ -150,7 +150,7 @@ namespace McMaster.DotNet.Serve
                 });
             }
 
-            if (_options.UseGzip || _options.UseBrotli)
+            if (_options.UseGzip == true || _options.UseBrotli == true)
             {
                 app.UseResponseCompression();
             }

--- a/src/dotnet-serve/dotnet-serve.csproj
+++ b/src/dotnet-serve/dotnet-serve.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" Publish="false"/>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
+    <PackageReference Include="dotnet-config-lib" Version="1.0.0-beta" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
   </ItemGroup>
 </Project>

--- a/test/dotnet-serve.Tests/CommandLineOptionsTests.cs
+++ b/test/dotnet-serve.Tests/CommandLineOptionsTests.cs
@@ -46,17 +46,24 @@ namespace McMaster.DotNet.Serve.Tests
             var type = typeof(CommandLineOptions);
             var property = type.GetProperty(propertyName);
 
-            var backingField = type
-              .GetFields(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
-              .First(field =>
-                field.Attributes.HasFlag(FieldAttributes.Private) &&
-                field.Attributes.HasFlag(FieldAttributes.InitOnly) &&
-                field.CustomAttributes.Any(attr => attr.AttributeType == typeof(CompilerGeneratedAttribute)) &&
-                (field.DeclaringType == property.DeclaringType) &&
-                field.FieldType.IsAssignableFrom(property.PropertyType) &&
-                field.Name.StartsWith("<" + property.Name + ">")
-              );
-            backingField.SetValue(options, value);
+            if (property.CanWrite)
+            {
+                property.SetValue(options, value);
+            }
+            else
+            {
+                var backingField = type
+                  .GetFields(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
+                  .First(field =>
+                    field.Attributes.HasFlag(FieldAttributes.Private) &&
+                    field.Attributes.HasFlag(FieldAttributes.InitOnly) &&
+                    field.CustomAttributes.Any(attr => attr.AttributeType == typeof(CompilerGeneratedAttribute)) &&
+                    (field.DeclaringType == property.DeclaringType) &&
+                    field.FieldType.IsAssignableFrom(property.PropertyType) &&
+                    field.Name.StartsWith("<" + property.Name + ">")
+                  );
+                backingField.SetValue(options, value);
+            }
         }
     }
 }

--- a/test/dotnet-serve.Tests/ConfigTests.cs
+++ b/test/dotnet-serve.Tests/ConfigTests.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNetConfig;
+using Xunit;
+
+namespace McMaster.DotNet.Serve.Tests
+{
+    public class ConfigTests
+    {
+        [Fact]
+        public void ConfigurationProvidesDefaultOptions()
+        {
+            var certFile = Path.GetTempFileName();
+            var keyFile = Path.GetTempFileName();
+            var pfxFile = Path.GetTempFileName();
+            var configFile = Path.GetTempFileName();
+
+            File.WriteAllText(configFile, @$"
+[config]
+    root
+
+[serve]
+    port = 4242
+    directory = {Path.GetTempPath().Replace("\\", "\\\\")}
+    open-browser
+    quiet = true
+    verbose = on
+    cert = {certFile.Replace("\\", "\\\\")}
+    key = {keyFile.Replace("\\", "\\\\")}
+    pfx = {pfxFile.Replace("\\", "\\\\")}
+    pfx-pwd = password
+    gzip
+    cors = yes
+    header = X-H1: value
+    header = X-H2: value
+    mime = .cs=text/plain
+    mime = .vb=text/plain
+    mime = .fs=text/plain
+    exclude-file = app.config
+    exclude-file = appsettings.json
+");
+
+            var program = new TestProgram();
+            program.Run("--config-file", configFile);
+
+            var options = program.Options;
+
+            Assert.True(options != null, string.Join(Environment.NewLine, program.Errors));
+
+            Assert.Equal(4242, options.Port);
+            Assert.Equal(Path.GetTempPath(), options.Directory);
+            Assert.True(options.OpenBrowser);
+            Assert.True(options.Quiet);
+            Assert.True(options.Verbose);
+            Assert.Equal(certFile, options.CertPemPath);
+            Assert.Equal(keyFile, options.PrivateKeyPath);
+            Assert.Equal(pfxFile, options.CertPfxPath);
+            Assert.Equal("password", options.CertificatePassword);
+            Assert.True(options.UseGzip);
+            Assert.True(options.EnableCors);
+
+            Assert.Contains("X-H1: value", options.Headers);
+            Assert.Contains("X-H2: value", options.Headers);
+
+            Assert.Contains(".cs=text/plain", options.MimeMappings);
+            Assert.Contains(".vb=text/plain", options.MimeMappings);
+            Assert.Contains(".fs=text/plain", options.MimeMappings);
+
+            Assert.Contains("app.config", options.ExcludedFiles);
+            Assert.Contains("appsettings.json", options.ExcludedFiles);
+        }
+
+        [Fact]
+        public void CommandLineOverridesConfiguration()
+        {
+            var certFile = Path.GetTempFileName();
+            var keyFile = Path.GetTempFileName();
+            var pfxFile = Path.GetTempFileName();
+            var configFile = Path.GetTempFileName();
+
+            File.WriteAllText(configFile, @$"
+[config]
+    root
+
+[serve]
+    port = 2424
+    directory = {Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData).Replace("\\", "\\\\")}
+    open-browser = false
+    quiet = false
+    verbose = false
+    cert = cert
+    key = key
+    pfx = pfx
+    pfx-pwd = pwd
+    gzip = 0
+    cors = no
+");
+
+            var program = new TestProgram();
+            program.Run(
+                "--config-file", configFile,
+                "-p", "4242",
+                "-d", Path.GetTempPath(),
+                "--cert", certFile,
+                "--key", keyFile,
+                "--pfx", pfxFile,
+                "--pfx-pwd", "password",
+                "-oqvzc");
+
+            var options = program.Options;
+
+            Assert.True(options != null, string.Join(Environment.NewLine, program.Errors));
+
+            Assert.Equal(4242, options.Port);
+            Assert.Equal(Path.GetTempPath(), options.Directory);
+            Assert.True(options.OpenBrowser);
+            Assert.True(options.Quiet);
+            Assert.True(options.Verbose);
+            Assert.Equal(certFile, options.CertPemPath);
+            Assert.Equal(keyFile, options.PrivateKeyPath);
+            Assert.Equal(pfxFile, options.CertPfxPath);
+            Assert.Equal("password", options.CertificatePassword);
+            Assert.True(options.UseGzip);
+            Assert.True(options.EnableCors);
+        }
+
+        [Fact]
+        public void ConfigurationHeadersAugmentOptions()
+        {
+            var configFile = Path.GetTempFileName();
+
+            File.WriteAllText(configFile, @$"
+[config]
+    root
+
+[serve]
+    header = X-H1: value
+");
+
+
+            var program = new TestProgram();
+            program.Run("--config-file", configFile, "-h", "X-H2: value");
+
+            var options = program.Options;
+
+            Assert.True(options != null, string.Join(Environment.NewLine, program.Errors));
+
+            Assert.Contains("X-H1: value", options.Headers);
+            Assert.Contains("X-H2: value", options.Headers);
+        }
+
+        [Fact]
+        public void ConfigurationMimeAugmentOptions()
+        {
+            var configFile = Path.GetTempFileName();
+
+            File.WriteAllText(configFile, @$"
+[config]
+    root
+
+[serve]
+    mime = .vb=text/plain
+    mime = .fs=text/plain
+");
+
+            var program = new TestProgram();
+            program.Run("--config-file", configFile, "-m", ".cs=text/plain");
+
+            var options = program.Options;
+
+            Assert.True(options != null, string.Join(Environment.NewLine, program.Errors));
+
+            Assert.Contains(".cs=text/plain", options.MimeMappings);
+            Assert.Contains(".vb=text/plain", options.MimeMappings);
+            Assert.Contains(".fs=text/plain", options.MimeMappings);
+        }
+
+        [Fact]
+        public void ConfigurationExcludedFilesAugmentOptions()
+        {
+            var configFile = Path.GetTempFileName();
+
+            File.WriteAllText(configFile, @$"
+[config]
+    root
+
+[serve]
+    exclude-file = app.config
+");
+
+            var program = new TestProgram();
+            program.Run("--config-file", configFile, "--exclude-file", "appsettings.json");
+
+            var options = program.Options;
+
+            Assert.True(options != null, string.Join(Environment.NewLine, program.Errors));
+
+            Assert.Contains("app.config", options.ExcludedFiles);
+            Assert.Contains("appsettings.json", options.ExcludedFiles);
+        }
+
+        class TestProgram : Program
+        {
+            protected override Task<int> OnRunAsync(CommandLineOptions options, CancellationToken ct)
+            {
+                Options = options;
+                return Task.FromResult(0);
+            }
+
+            public CommandLineOptions Options { get; private set; }
+        }
+    }
+}


### PR DESCRIPTION
The [dotnetconfig](https://dotnetconfig.org) format allows hierarchical
tool settings to be persisted and read in a standards way. By adding
this support to the tool, all options can now be persisted to the
`.netconfig` in the current directory to streamline subsequent runs.

When running `dotnet serve .... --save`, the options will be saved
to the current directory `.netconfig` file and can be inspected to
learn the format. Afterwards, the options can be moved if desired
to another `.netconfig` file in any ancestor directory so it's reused
across runs from any descendent folder. Or it can also be saved to the
global or system locations too.

Updated the readme too to showcase this new feature.

As an example, moved a few arguments from the launchSettings.json to
a .netconfig in the project directory, which now augments the startup
arguments from config :).