### PR TITLE
Bump to new beta of DotNetConfig with support for relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,6 @@ dotnet config --global --set serve.port 8000
 
 This will default the port to `8000` whenever a port is not specified in the command line. You 
 can open the saved `.netconfig` at `%USERPROFILE%\.netconfig` or `~/.netconfig`.
+
+The `cert`, `key` and `pfx` values, in particular, can be relative paths that are resolved
+relative to the location of the declaring `.netconfig` file, which can be very convenient.

--- a/src/dotnet-serve/Program.cs
+++ b/src/dotnet-serve/Program.cs
@@ -75,9 +75,9 @@ namespace McMaster.DotNet.Serve
             model.OpenBrowser ??= config.GetBoolean("open-browser"); 
             model.Quiet ??= config.GetBoolean("quiet");
             model.Verbose ??= config.GetBoolean("verbose");
-            model.CertPemPath ??= config.GetString("cert");
-            model.PrivateKeyPath ??= config.GetString("key");
-            model.CertPfxPath ??= config.GetString("pfx");
+            model.CertPemPath ??= config.GetNormalizedPath("cert");
+            model.PrivateKeyPath ??= config.GetNormalizedPath("key");
+            model.CertPfxPath ??= config.GetNormalizedPath("pfx");
             model.CertificatePassword ??= config.GetString("pfx-pwd");
             model.UseGzip ??= config.GetBoolean("gzip");
             model.UseBrotli ??= config.GetBoolean("brotli");

--- a/src/dotnet-serve/dotnet-serve.csproj
+++ b/src/dotnet-serve/dotnet-serve.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" Publish="false"/>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
-    <PackageReference Include="dotnet-config-lib" Version="1.0.0-beta" />
+    <PackageReference Include="DotNetConfig" Version="1.0.0-beta" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The configurations that make the most sense for config-relative paths
are likely just the certificate related ones.