### PR TITLE
Add missing path-base option from .netconfig

### DIFF
--- a/src/dotnet-serve/CommandLineOptions.cs
+++ b/src/dotnet-serve/CommandLineOptions.cs
@@ -37,7 +37,7 @@ namespace McMaster.DotNet.Serve
         public IPAddress[] Addresses { get; }
 
         [Option("--path-base <PATH>", Description = "The base URL path of postpended to the site url.")]
-        private string PathBase { get; }
+        public string PathBase { get; internal set; }
 
         [Option("--default-extensions:<EXTENSIONS>", CommandOptionType.SingleOrNoValue, Description = "A comma-delimited list of extensions to use when no extension is provided in the URL. [.html,.htm]")]
         public (bool HasValue, string Extensions) DefaultExtensions { get; }

--- a/src/dotnet-serve/Program.cs
+++ b/src/dotnet-serve/Program.cs
@@ -82,6 +82,7 @@ namespace McMaster.DotNet.Serve
             model.UseGzip ??= config.GetBoolean("gzip");
             model.UseBrotli ??= config.GetBoolean("brotli");
             model.EnableCors ??= config.GetBoolean("cors");
+            model.PathBase ??= config.GetString("path-base");
 
             if (!model.UseTlsSpecified && config.TryGetBoolean("tls", out var tls))
             {

--- a/test/dotnet-serve.Tests/ConfigTests.cs
+++ b/test/dotnet-serve.Tests/ConfigTests.cs
@@ -40,6 +40,7 @@ namespace McMaster.DotNet.Serve.Tests
     mime = .fs=text/plain
     exclude-file = app.config
     exclude-file = appsettings.json
+    path-base = foo
 ");
 
             var program = new TestProgram();
@@ -60,6 +61,7 @@ namespace McMaster.DotNet.Serve.Tests
             Assert.Equal("password", options.CertificatePassword);
             Assert.True(options.UseGzip);
             Assert.True(options.EnableCors);
+            Assert.Equal("foo", options.PathBase);
 
             Assert.Contains("X-H1: value", options.Headers);
             Assert.Contains("X-H2: value", options.Headers);


### PR DESCRIPTION
This option was not writtable in the model and was therefore
not set when loading from configuration.