### PR TITLE
Implement `--reverse-proxy <SOURCE_PATH_PATTERN>=<DESTINATION_URL_PREFIX>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ dotnet serve -o -S
 Usage: dotnet serve [options]
 
 Options:
-  --version                            Show version information
+  --version                            Show version information.
   -d|--directory <DIR>                 The root directory to serve. [Current directory]
   -o|--open-browser                    Open a web browser when the server starts. [false]
   -p|--port <PORT>                     Port to use [8080]. Use 0 for a dynamic port.
   -a|--address <ADDRESS>               Address to use [127.0.0.1]
   --path-base <PATH>                   The base URL path of postpended to the site url.
+  --reverse-proxy <MAPPING>            Map a path pattern to another url.
+                                       Expected format is <SOURCE_PATH_PATTERN>=<DESTINATION_URL_PREFIX>.
+                                       SOURCE_PATH_PATTERN uses ASP.NET routing syntax. Use {**all} to match anything.
   --default-extensions[:<EXTENSIONS>]  A comma-delimited list of extensions to use when no extension is provided in the URL. [.html,.htm]
   -q|--quiet                           Show less console output.
   -v|--verbose                         Show more console output.
@@ -65,7 +68,8 @@ Options:
   -b|--brotli                          Enable brotli compression
   -c|--cors                            Enable CORS (It will enable CORS for all origin and all methods)
   --save-options                       Save specified options to .netconfig for subsequent runs.
-  -?|--help                            Show help information
+  --config-file                        Use the given .netconfig file.
+  -?|--help                            Show help information.
 ```
 
 > Tip: single letters for options can be combined. Example: `dotnet serve -Sozq`
@@ -110,6 +114,16 @@ When serving on 'localhost', dotnet-serve will discover and use when you run:
 ```
 dotnet serve -S
 ```
+
+## Reverse Proxy
+
+`dotnet-serve --reverse-proxy /api/{**all}=http://localhost:5000`
+will proxy all requests matching `/api/*` to `http://localhost:5000/api/*`.
+
+The source path pattern uses ASP.NET routing syntax.
+[See the ASP.NET docs for more info.](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/routing?view=aspnetcore-5.0#route-template-reference)
+
+Multiple `--reverse-proxy <MAPPING>` directives can be defined.
 
 ## Reusing options with .netconfig
 

--- a/src/dotnet-serve/Program.cs
+++ b/src/dotnet-serve/Program.cs
@@ -115,6 +115,22 @@ internal class Program
             }
         }
 
+        var reverseProxies = config.GetAll("reverse-proxy").Select(e => e.RawValue).ToArray();
+        if (reverseProxies.Length > 0)
+        {
+            if (model.ReverseProxyMappings == null)
+            {
+                model.ReverseProxyMappings = reverseProxies;
+            }
+            else
+            {
+                var all = new string[model.ReverseProxyMappings.Length + reverseProxies.Length];
+                model.ReverseProxyMappings.CopyTo(all, 0);
+                reverseProxies.CopyTo(all, model.ReverseProxyMappings.Length);
+                model.ReverseProxyMappings = all;
+            }
+        }
+
         model.ExcludedFiles.AddRange(
             config.GetAll("exclude-file").Select(x => x.RawValue));
     }
@@ -183,6 +199,14 @@ internal class Program
             foreach (var mime in model.MimeMappings)
             {
                 config.AddString("mime", mime);
+            }
+        }
+
+        if (model.ReverseProxyMappings != null)
+        {
+            foreach (var reverseProxy in model.ReverseProxyMappings)
+            {
+                config.AddString("reverse-proxy", reverseProxy);
             }
         }
 

--- a/src/dotnet-serve/Properties/launchSettings.json
+++ b/src/dotnet-serve/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "dotnet-serve": {
       "commandName": "Project",
-      "commandLineArgs": "-p 5043 -h \"X-XSS-Protection: 1; mode=block\" ",
+      "commandLineArgs": "-p 5043 --reverse-proxy /api/{**all}=http://localhost:5000",
       "workingDirectory": "$(MSBuildProjectDirectory)"
     }
   }

--- a/src/dotnet-serve/dotnet-serve.csproj
+++ b/src/dotnet-serve/dotnet-serve.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="DotNetConfig" Version="1.0.6" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0" />
 
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/test/dotnet-serve.Tests/DotNetServe.cs
+++ b/test/dotnet-serve.Tests/DotNetServe.cs
@@ -100,6 +100,7 @@ internal class DotNetServe : IDisposable
         string certPassword = null,
         string[] mimeMap = null,
         string[] headers = null,
+        string[] reverseProxyMap = null,
         ITestOutputHelper output = null,
         bool useGzip = false,
         bool useBrotli = false,
@@ -148,6 +149,15 @@ internal class DotNetServe : IDisposable
             foreach (var mapping in mimeMap)
             {
                 psi.ArgumentList.Add("-m");
+                psi.ArgumentList.Add(mapping);
+            }
+        }
+
+        if (reverseProxyMap != null)
+        {
+            foreach (var mapping in reverseProxyMap)
+            {
+                psi.ArgumentList.Add("--reverse-proxy");
                 psi.ArgumentList.Add(mapping);
             }
         }

--- a/test/dotnet-serve.Tests/ReverseProxyTests.cs
+++ b/test/dotnet-serve.Tests/ReverseProxyTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace McMaster.DotNet.Serve.Tests;
+
+public class ReverseProxyTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public ReverseProxyTests(ITestOutputHelper output)
+    {
+        this._output = output;
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ItAppliesReverseProxies(bool enableProxy)
+    {
+        var backendPath = Path.Combine(AppContext.BaseDirectory, "TestAssets", "ReverseProxy", "Backend");
+        var frontendPath = Path.Combine(AppContext.BaseDirectory, "TestAssets", "ReverseProxy", "Frontend");
+
+        using var backendServer = DotNetServe.Start(backendPath, output: _output);
+
+        string[] proxyMapping = Array.Empty<string>();
+        if (enableProxy)
+        {
+            // Proxy the path /api.json to the backend:
+            proxyMapping = new[] { $"/api.json={backendServer.Client.BaseAddress}" };
+        }
+
+        using var frontendServer = DotNetServe.Start(frontendPath, output: _output, reverseProxyMap: proxyMapping);
+
+        // Sanity checks:
+        Assert.Equal(System.Net.HttpStatusCode.OK, (await frontendServer.Client.GetWithRetriesAsync("/file.html")).StatusCode);
+        Assert.Equal(System.Net.HttpStatusCode.NotFound, (await backendServer.Client.GetWithRetriesAsync("/file.html")).StatusCode);
+        Assert.Equal(System.Net.HttpStatusCode.OK, (await backendServer.Client.GetWithRetriesAsync("/api.json")).StatusCode);
+
+        // Actual proxy test:
+        var request = await frontendServer.Client.GetWithRetriesAsync("/api.json");
+        if (enableProxy)
+        {
+            Assert.Equal(System.Net.HttpStatusCode.OK, request.StatusCode);
+        }
+        else
+        {
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, request.StatusCode);
+        }
+    }
+}

--- a/test/dotnet-serve.Tests/TestAssets/ReverseProxy/Backend/api.json
+++ b/test/dotnet-serve.Tests/TestAssets/ReverseProxy/Backend/api.json
@@ -1,0 +1,1 @@
+﻿{ "greetings": "hello!" }

--- a/test/dotnet-serve.Tests/TestAssets/ReverseProxy/Frontend/file.html
+++ b/test/dotnet-serve.Tests/TestAssets/ReverseProxy/Frontend/file.html
@@ -1,0 +1,1 @@
+﻿<html>whatever</html>


### PR DESCRIPTION
I would like to use `dotnet-serve` as a convenient and easy way to setup a [Fable](https://fable.io/) development environment while staying in the .NET world, and one thing that is missing is a reverse proxy feature so I can quickly iterate on the frontend while keeping a backend api running separately. 

I saw that I'm not the first to want a reverse proxy (#11), but it looks like the last person lost interest...

This PR implements a `--reverse-proxy <SOURCE_PATH_PATTERN>=<DESTINATION_URL_PREFIX>` directive, using https://github.com/microsoft/reverse-proxy (YARP)

It seems to work great, and was easy enough to implement, even though YARP is still in preview.

One drawback is that YARP does not support .NET Core 2.1, so its support in dotnet-serve would have to be dropped. (Or we would need to add lots of `#if NETCOREAPP2_1`)
I'm not sure it's a big problem: after all `dotnet-serve` is a tool, so it's likely to be run on up-to-date versions of .NET don't you think?

I added some unit tests for the configuration and for the feature itself.

I cleaned up existing `#if NETCOREAPP2_1` in a separate commit since I wasn't sure you were ready to drop its support completely. If you absolutely want to keep this target, I could drop this commit and wrap all the reverse proxy related stuff in new `#if NETCOREAPP2_1` instead (please don't make me do that).

Tell me what you think! :)