### PR TITLE
Drop support for .NET Core 2.1 and 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup .NET Core 2.1
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: "2.1.x"
-      - name: Setup .NET Core 3.1
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: "3.1.x"
-      - name: Setup .NET 5
+      - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: "5.0.x"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It launches a server in the current working directory and serves all files in it
 
 ## Get started
 
-[Install .NET Core or .NET 5+](https://get.dot.net) and run this command:
+[Install .NET 5 or newer](https://get.dot.net) and run this command:
 
 ```
 dotnet tool install --global dotnet-serve
@@ -62,7 +62,7 @@ Options:
   -m|--mime <MAPPING>                  Add a mapping from file extension to MIME type. Empty MIME removes a mapping.
                                        Expected format is <EXT>=<MIME>.
   -z|--gzip                            Enable gzip compression
-  -b|--brotli                          Enable brotli compression (requires .NET Core 3+)
+  -b|--brotli                          Enable brotli compression
   -c|--cors                            Enable CORS (It will enable CORS for all origin and all methods)
   --save-options                       Save specified options to .netconfig for subsequent runs.
   -?|--help                            Show help information

--- a/src/dotnet-serve/CommandLineOptions.cs
+++ b/src/dotnet-serve/CommandLineOptions.cs
@@ -121,9 +121,7 @@ namespace McMaster.DotNet.Serve
         [Option("-z|--gzip", Description = "Enable gzip compression")]
         public bool? UseGzip { get; internal set; }
 
-#if !NETCOREAPP2_1
         [Option("-b|--brotli", Description = "Enable brotli compression")]
-#endif
         public bool? UseBrotli { get; internal set; }
 
         [Option("-c|--cors", Description = "Enable CORS (It will enable CORS for all origin and all methods)")]

--- a/src/dotnet-serve/DefaultExtensions/DefaultExtensionsMiddleware.cs
+++ b/src/dotnet-serve/DefaultExtensions/DefaultExtensionsMiddleware.cs
@@ -9,10 +9,6 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-#if NETCOREAPP2_1
-using IWebHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
-#endif
-
 namespace McMaster.DotNet.Serve.DefaultExtensions
 {
     internal class DefaultExtensionsMiddleware

--- a/src/dotnet-serve/Startup.cs
+++ b/src/dotnet-serve/Startup.cs
@@ -15,10 +15,6 @@ using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
 
-#if NETCOREAPP2_1
-using IWebHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
-#endif
-
 namespace McMaster.DotNet.Serve
 {
     internal class Startup
@@ -56,12 +52,10 @@ namespace McMaster.DotNet.Serve
                 }
 
 
-#if !NETCOREAPP2_1
                 if (_options.UseBrotli == true)
                 {
                     options.Providers.Add<BrotliCompressionProvider>();
                 }
-#endif
             });
         }
 

--- a/src/dotnet-serve/dotnet-serve.csproj
+++ b/src/dotnet-serve/dotnet-serve.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" Publish="false" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="DotNetConfig" Version="1.0.6" />

--- a/src/dotnet-serve/dotnet-serve.csproj
+++ b/src/dotnet-serve/dotnet-serve.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <AssemblyName>dotnet-serve</AssemblyName>
@@ -11,14 +11,6 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <RootNamespace>McMaster.DotNet.Serve</RootNamespace>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" Publish="false" />

--- a/src/dotnet-serve/releasenotes.props
+++ b/src/dotnet-serve/releasenotes.props
@@ -1,5 +1,8 @@
 <Project>
   <PropertyGroup>
+    <PackageReleaseNotes Condition=" $(VersionPrefix.StartsWith('1.9.')) ">
+Dropped support for running on older versions of .NET Core. This tool now requires .NET 5 or newer.
+    </PackageReleaseNotes>
     <PackageReleaseNotes Condition=" $(VersionPrefix.StartsWith('1.7.')) ">
 Improvement:
 * @ansariabr: add support for a --cors options which can be used to enable CORS and OPTIONS requests (#45)

--- a/test/dotnet-serve.Tests/DotNetServe.cs
+++ b/test/dotnet-serve.Tests/DotNetServe.cs
@@ -16,16 +16,7 @@ namespace McMaster.DotNet.Serve.Tests
         private static readonly string s_dotnetServe
             = Path.Combine(AppContext.BaseDirectory, "tool", "dotnet-serve.dll");
 
-        private static int s_nextPort
-#if NETCOREAPP2_1 // avoid conflicts if tests for both target frameworks run at the same time.
-            = 9000;
-#elif NETCOREAPP3_1
-            = 10000;
-#elif NET5_0
-            = 11000;
-#else
-#error Update target frameworks
-#endif
+        private static int s_nextPort = 9000;
 
         private readonly Process _process;
         private readonly ITestOutputHelper _output;

--- a/test/dotnet-serve.Tests/OptionsRequestTest.cs
+++ b/test/dotnet-serve.Tests/OptionsRequestTest.cs
@@ -29,11 +29,7 @@ namespace McMaster.DotNet.Serve.Tests
             return headers;
         }
 
-#if NETCOREAPP2_1
-        [Fact(Skip = "Not sure why, but this fails on GitHub workers")]
-#else
         [Fact]
-#endif
         public async Task ItAllowsOptionsRequestIfCORSIsEnabled()
         {
             using var ds = DotNetServe.Start(enableCors: true, output: _output);

--- a/test/dotnet-serve.Tests/dotnet-serve.Tests.csproj
+++ b/test/dotnet-serve.Tests/dotnet-serve.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestAssets\**\*;TestResults\**\*</DefaultItemExcludes>
     <RootNamespace>McMaster.DotNet.Serve.Tests</RootNamespace>
   </PropertyGroup>
@@ -10,19 +10,8 @@
     <Content Include="TestAssets\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <Compile Remove="BrotliTests.cs" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\dotnet-serve\dotnet-serve.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <!-- Required becuase the SDK doesn't do transitive package refs from PackAsTool for netcoreapp2.1 -->
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Simplifying the code to run on a single version of .NET. Choosing .NET 5 as it has been stable for some time. Motivated by noticing that .NET Core 2.1 is no longer supported by Microsoft.