### PR TITLE
Compile for .NET 6

### DIFF
--- a/src/dotnet-serve/dotnet-serve.csproj
+++ b/src/dotnet-serve/dotnet-serve.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <AssemblyName>dotnet-serve</AssemblyName>

--- a/test/dotnet-serve.Tests/DotNetServe.cs
+++ b/test/dotnet-serve.Tests/DotNetServe.cs
@@ -11,7 +11,15 @@ internal class DotNetServe : IDisposable
     private static readonly string s_dotnetServe
         = Path.Combine(AppContext.BaseDirectory, "tool", "dotnet-serve.dll");
 
-    private static int s_nextPort = 9000;
+    private static int s_nextPort
+        // separate port ranges per framework when tests are run in parallel
+#if NET5_0
+        = 9000;
+#elif NET6_0
+        = 10000;
+#else
+#error Update target frameworks
+#endif
 
     private readonly Process _process;
     private readonly ITestOutputHelper _output;

--- a/test/dotnet-serve.Tests/dotnet-serve.Tests.csproj
+++ b/test/dotnet-serve.Tests/dotnet-serve.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <DefaultItemExcludes>$(DefaultItemExcludes);TestAssets\**\*;TestResults\**\*</DefaultItemExcludes>
     <RootNamespace>McMaster.DotNet.Serve.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <Content Include="TestAssets\**" CopyToOutputDirectory="PreserveNewest" />
-    <Using Include="Xunit"/>
-    <Using Include="Xunit.Abstractions"/>
+    <Using Include="Xunit" />
+    <Using Include="Xunit.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Helps ensure the tool works when .NET 5 isn't available.