### PR TITLE
Set RollForward policy for dotnet-serve global tool

### DIFF
--- a/src/dotnet-serve/dotnet-serve.csproj
+++ b/src/dotnet-serve/dotnet-serve.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
+    <RollForward>Major</RollForward>
     <AssemblyName>dotnet-serve</AssemblyName>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
This allows dotnet-serve to execute on a higher dotnet version if the requested one is not installed.
