### PR TITLE
Fixed localport listening for docker containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
+{
+	"name": "C# (.NET)",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/dotnet:0-7.0",
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [5000, 5001],
+	// "portsAttributes": {
+	//		"5001": {
+	//			"protocol": "https"
+	//		}
+	// }
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "dotnet restore",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/src/dotnet-serve/SimpleServer.cs
+++ b/src/dotnet-serve/SimpleServer.cs
@@ -73,7 +73,7 @@ internal class SimpleServer
                     }
                     else
                     {
-                        o.ListenLocalhost(port.GetValueOrDefault(), ConfigureHttps);
+                        o.ListenAnyIP(port.GetValueOrDefault(), ConfigureHttps);
                     }
                 }
                 else


### PR DESCRIPTION
The existing implementation does not work in the docker container: you can't use automatic port assignment because the desired port should be declared. But, if you set the port as a parameter the Kestrel ListenLocalhost() will allow only internal connections that prevents use outside the container. 