### PR TITLE
Allow providing a path to `--open-browser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ Usage: dotnet serve [options]
 Options:
   --version                            Show version information.
   -d|--directory <DIR>                 The root directory to serve. [Current directory]
-  -o|--open-browser                    Open a web browser when the server starts. [false]
+  -o|--open-browser[:<PATH>]           Open a web browser when the server starts. [Default false]
+                                       You can also provide the subpath to launch by using -o:<PATH>.
+                                       Example: -o:/path/index.html
   -p|--port <PORT>                     Port to use [8080]. Use 0 for a dynamic port.
   -a|--address <ADDRESS>               Address to use. [Default = localhost].
                                        Accepts IP addresses,

--- a/src/dotnet-serve/.netconfig
+++ b/src/dotnet-serve/.netconfig
@@ -6,3 +6,4 @@
 	mime = .csproj=text/xml
 	exclude-file = dotnet-serve.csproj
 	exclude-file = releasenotes.props
+	open-browser

--- a/src/dotnet-serve/.netconfig
+++ b/src/dotnet-serve/.netconfig
@@ -6,4 +6,3 @@
 	mime = .csproj=text/xml
 	exclude-file = dotnet-serve.csproj
 	exclude-file = releasenotes.props
-	open-browser

--- a/src/dotnet-serve/CommandLineOptions.cs
+++ b/src/dotnet-serve/CommandLineOptions.cs
@@ -23,8 +23,8 @@ internal class CommandLineOptions
     [DirectoryExists]
     public string Directory { get; internal set; }
 
-    [Option(Description = "Open a web browser when the server starts. [false]")]
-    public bool? OpenBrowser { get; internal set; }
+    [Option("-o|--open-browser[:<PATH>]", CommandOptionType.SingleOrNoValue, Description = "Open a web browser when the server starts. [Default = false]\nYou can also provide the subpath to launch by using -o:<PATH>.\nExample: -o:/path/index.html")]
+    public (bool hasValue, string path) OpenBrowser { get; internal set; }
 
     [Option(Description = "Port to use [8080]. Use 0 for a dynamic port.")]
     [Range(0, 65535, ErrorMessage = "Invalid port. Ports must be in the range of 0 to 65535.")]

--- a/src/dotnet-serve/SimpleServer.cs
+++ b/src/dotnet-serve/SimpleServer.cs
@@ -132,16 +132,21 @@ internal class SimpleServer
         _console.WriteLine("");
         _console.WriteLine("Press CTRL+C to exit");
 
-        if (_options.OpenBrowser == true)
+        if (_options.OpenBrowser.hasValue)
         {
             var url = NormalizeToLoopbackAddress(addresses.Addresses.First());
+            var uri = new Uri(url);
 
-            if (!string.IsNullOrEmpty(pathBase))
+            if (!string.IsNullOrWhiteSpace(_options.OpenBrowser.path))
             {
-                url += pathBase;
+                uri = new Uri(uri, _options.OpenBrowser.path);
+            }
+            else if (!string.IsNullOrEmpty(pathBase))
+            {
+                uri = new Uri(uri, pathBase);
             }
 
-            LaunchBrowser(url);
+            LaunchBrowser(uri.ToString());
         }
 
         static string GetListeningAddressText(IServerAddressesFeature addresses)

--- a/src/dotnet-serve/SimpleServer.cs
+++ b/src/dotnet-serve/SimpleServer.cs
@@ -134,8 +134,7 @@ internal class SimpleServer
 
         if (_options.OpenBrowser.hasValue)
         {
-            var url = NormalizeToLoopbackAddress(addresses.Addresses.First());
-            var uri = new Uri(url);
+            var uri = new Uri(NormalizeToLoopbackAddress(addresses.Addresses.First()));
 
             if (!string.IsNullOrWhiteSpace(_options.OpenBrowser.path))
             {

--- a/test/dotnet-serve.Tests/ConfigTests.cs
+++ b/test/dotnet-serve.Tests/ConfigTests.cs
@@ -51,7 +51,7 @@ public class ConfigTests
 
         Assert.Equal(4242, options.Port);
         Assert.Equal(Path.GetTempPath(), options.Directory);
-        Assert.True(options.OpenBrowser);
+        Assert.True(options.OpenBrowser.hasValue);
         Assert.True(options.Quiet);
         Assert.True(options.Verbose);
         Assert.Equal(certFile, options.CertPemPath);
@@ -123,7 +123,7 @@ public class ConfigTests
 
         Assert.Equal(4242, options.Port);
         Assert.Equal(Path.GetTempPath(), options.Directory);
-        Assert.True(options.OpenBrowser);
+        Assert.True(options.OpenBrowser.hasValue);
         Assert.True(options.Quiet);
         Assert.True(options.Verbose);
         Assert.Equal(certFile, options.CertPemPath);


### PR DESCRIPTION
## What
Change `--open-browser` to a SingleOrNoValue option type.
## Why
This allows users to give the starting path to be launched.

Closes https://github.com/natemcmaster/dotnet-serve/issues/141
## Testing
did lots of manual testing of combinations of CLI + .netconfig files to validate it opens the browser to the path given.